### PR TITLE
当登录失败时，保持登陆的close图标和失败前UI一致

### DIFF
--- a/src/net/oschina/app/ui/LoginDialog.java
+++ b/src/net/oschina/app/ui/LoginDialog.java
@@ -134,6 +134,7 @@ public class LoginDialog extends Activity{
 					}
 				}else if(msg.what == 0){
 					mViewSwitcher.showPrevious();
+					btn_close.setVisibility(View.VISIBLE);
 					UIHelper.ToastMessage(LoginDialog.this, getString(R.string.msg_login_fail)+msg.obj);
 				}else if(msg.what == -1){
 					mViewSwitcher.showPrevious();


### PR DESCRIPTION
登陆的时候，右上角有个close图标，登录失败的话则有没有这个close图标，UI上不一致。
