### PR TITLE
将oschina的分享功能扩充，写成通用的形式

### DIFF
--- a/src/net/oschina/app/common/UIHelper.java
+++ b/src/net/oschina/app/common/UIHelper.java
@@ -46,6 +46,7 @@ import net.oschina.app.ui.UserCenter;
 import net.oschina.app.ui.UserFavorite;
 import net.oschina.app.ui.UserFriend;
 import net.oschina.app.ui.UserInfo;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
@@ -386,13 +387,24 @@ public class UIHelper {
 		context.startActivity(intent);
 	}
 	
+	public static void showShareDialog(final Activity context,final String title,final String url)
+	{
+		//分享的内容
+		final String shareMessage = title + " " +url;
+		
+		Intent intent=new Intent(Intent.ACTION_SEND);        
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, shareMessage);
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.footbar_share)));
+	}
+	
 	/**
 	 * 分享到'新浪微博'或'腾讯微博'的对话框
 	 * @param context 当前Activity
 	 * @param title	分享的标题
 	 * @param url 分享的链接
 	 */
-	public static void showShareDialog(final Activity context,final String title,final String url)
+	public static void showShareDialogSinaAndQQ(final Activity context,final String title,final String url)
 	{
 		AlertDialog.Builder builder = new AlertDialog.Builder(context);
 		builder.setIcon(android.R.drawable.btn_star);
@@ -982,6 +994,7 @@ public class UIHelper {
 	 * @param objecttitle
 	 * @return
 	 */
+	@SuppressLint({ "NewApi", "NewApi" })
 	public static SpannableString parseActiveAction(String author,int objecttype,int objectcatalog,String objecttitle){
 		String title = "";
 		int start = 0;


### PR DESCRIPTION
将oschina的分享功能扩充，写成通用的形式，这样只要其他应用程序支持分享功能，oschina就可以将内容分享到该应用程序。比如：不仅可以分享新浪微博、腾讯微博，还可以分享到人人、短信、蓝牙、gmail、github等。
